### PR TITLE
Compliance: Moves add- and amend_fields to compliance_check

### DIFF
--- a/compliance_check.py
+++ b/compliance_check.py
@@ -18,7 +18,24 @@
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 from invenio.NonComplianceCheck import NonComplianceChecks
-from invenio.utils import amend_fields, add_fields
+
+
+def amend_fields(record, field, changes_dict, comment=''):
+    """record : AmendableRecord"""
+    for position, value in record.iterfield(field):
+        key = value[:value.find(':')]
+        if key in changes_dict:
+            record.amend_field(position,
+                               '%s:%d' % (key, changes_dict[key]),
+                               comment)
+
+
+def add_fields(record, field, subfield, value_dict):
+    """record : AmendableRecord"""
+    for key, value in value_dict.iteritems():
+        record.add_field(field,
+                         value="",
+                         subfields=[(subfield, '%s:%d' % (key, value))])
 
 
 def check_records(records, empty=False):

--- a/utils.py
+++ b/utils.py
@@ -45,24 +45,6 @@ def get_rawtext_from_record_id(record_id):
     return rawtext
 
 
-def amend_fields(record, field, changes_dict, comment=''):
-    """record : AmendableRecord"""
-    for position, value in record.iterfield(field):
-        key = value[:value.find(':')]
-        if key in changes_dict:
-            record.amend_field(position,
-                               '%s:%d' % (key, changes_dict[key]),
-                               comment)
-
-
-def add_fields(record, field, subfield, value_dict):
-    """record : AmendableRecord"""
-    for key, value in value_dict.iteritems():
-        record.add_field(field,
-                         value="",
-                         subfields=[(subfield, '%s:%d' % (key, value))])
-
-
 #GENERAL
 def get_filenames_from_directory(dirname, _filter=''):
     return [join(dirname, f) for f in listdir(dirname)


### PR DESCRIPTION
- Due to missing generality, the functions add_fields and
  amend_fields are moved from utils.py to compliance_check.py

Signed-off-by: Martin Vesper martin.vesper@cern.ch
