### PR TITLE
Nations: Affiliation adjustments

### DIFF
--- a/check_nations.py
+++ b/check_nations.py
@@ -9,15 +9,19 @@ def find_nations(field, subfields):
             values = [x.replace('.', '') for x in x[1].split(', ')]
             possible_affs = filter(lambda x: x is not None,
                                    map(NATIONS_DEFAULT_MAP.get, values))
-            if len(possible_affs) == 1:
-                result.append(possible_affs[0])
-            else:
-                result.append('HUMAN CHECK')
+            if 'CERN' in possible_affs and 'Switzerland' in possible_affs:
+                # Don't use remove in case of multiple Switzerlands
+                possible_affs = [x for x in possible_affs
+                                 if x != 'Switzerland']
 
-    if len(result) == 1:
-        return result[0]
+            result.extend(possible_affs)
+
+    result = sorted(list(set(result)))
+
+    if result:
+        return result
     else:
-        return 'HUMAN CHECK'
+        return ['HUMAN CHECK']
 
 
 def has_field(field, subfield):
@@ -36,5 +40,7 @@ def check_records(records, empty=False):
                 for i, x in enumerate(record[field]):
                     data = x[0]
                     if not has_field(data, 'w'):
-                        val = find_nations(data, ['u', 'v'])
-                        record.add_subfield((field + '__w', i, 0), 'w', val)
+                        values = find_nations(data, ['u', 'v'])
+                        for val in values:
+                            record.add_subfield((field + '__w', i, 0),
+                                                'w', val)

--- a/nations.py
+++ b/nations.py
@@ -11,8 +11,7 @@ from invenio.bibrecord import record_get_field_value
 from invenio.dbquery import run_sql
 from invenio.utils import NATIONS_DEFAULT_MAP, multi_replace
 
-_AFFILIATIONS = (['CERN']
-                 + sorted(list(set(NATIONS_DEFAULT_MAP.values())))
+_AFFILIATIONS = (sorted(list(set(NATIONS_DEFAULT_MAP.values())))
                  + ['HUMAN CHECK'])
 
 CFG_JOURNALS = ['Acta',
@@ -134,14 +133,7 @@ CFG_SELECTED_AFF = {'Andrews University':
                     'Yale University': ('Yale University',)}
 
 
-def filter_results_for_cern(results):
-    cern_results = perform_request_search(p='affiliation:CERN')
-    return list(set(results) - set(cern_results))
-
-
 def _build_query(nation):
-    if nation == 'CERN':
-        return 'affiliation:CERN'
     return "100__w:'{0}' OR 700__w:'{0}'".format(nation)
 
 
@@ -163,8 +155,6 @@ def index(req):
     for i, nation in enumerate(_AFFILIATIONS):
         query = _build_query(nation)
         results = perform_request_search(p=query, of='intbitset')
-        if nation == 'Switzerland':
-            results = filter_results_for_cern(results)
         req.write(tr.format(escape(nation),
                             escape(urlencode([("p", query)]), True),
                             len(results),
@@ -242,8 +232,6 @@ def articles(req, i, mode='html'):
         results = perform_request_search(p=query, cc=journal, of='intbitset')
         if not results:
             continue
-        if nation == 'Switzerland':
-            results = filter_results_for_cern(results)
         ret.append("<h2>%s (%s)</h2" % (escape(get_coll_i18nname(journal)),
                                         len(results)))
         ret.append("<p><ul>")
@@ -257,8 +245,8 @@ def articles(req, i, mode='html'):
             if mode == 'text':
                 print >> req, "http://dx.doi.org/%s" % doi
 
-            li = ("<li><a href='http://dx.doi.org/%s' "
-                  "target='_blank'>{0}</a>: {1}</li>")
+            li = ("<li><a href='http://dx.doi.org/{0}' "
+                  "target='_blank'>{1}</a>: {2}</li>")
             ret.append(li.format(escape(doi, True), escape(doi), title))
         ret.append("</ul></p>")
     body = '\n'.join(ret)

--- a/utils.py
+++ b/utils.py
@@ -22,6 +22,10 @@ NATIONS_DEFAULT_MAP = {"Algeria": "Algeria",
                        "Brazil": "Brazil",
                        "Bulgaria": "Bulgaria",
                        "Canada": "Canada",
+                       ##########CERN########
+                       "CERN": "CERN",
+                       "Cern": "CERN",
+                       #######################
                        "Chile": "Chile",
                        ##########CHINA########
                        "China (PRC)": "China",


### PR DESCRIPTION
- check_nations.py now allows multiple affiliations. Those are
  added as individual subfields (100__w or 700__w).
- CERN is now added to NATIONS_DEFAULT_MAP. Picking CERN over
  Switzerland in case both are in the same affiliation.
- nations.py is now also uses the fields 100__w or 700__w to
  find the records affiliated to CERN.

Signed-off-by: Martin Vesper martin.vesper@cern.ch
