### PR TITLE
rawtext_search: Adds configurability of search delimiters

### DIFF
--- a/NonComplianceCheck.py
+++ b/NonComplianceCheck.py
@@ -1,7 +1,3 @@
-from os import listdir
-from os.path import isfile
-from invenio.bibtask import write_message
-
 from string import maketrans
 
 from invenio.rawtext_search import RawTextSearch
@@ -11,8 +7,12 @@ from invenio.utils import (get_publisher, get_rawtext_from_record_id,
 
 
 class NonComplianceChecks:
-    def __init__(self, files_path, compliance_names):
+    def __init__(self, files_path, compliance_names,
+                 normal_search_delimiter="'", regex_search_delimiter="/"):
         self._non_compliance_checks = {}
+
+        self.normal_search_delimiter = normal_search_delimiter
+        self.regex_search_delimiter = regex_search_delimiter
 
         self._file_path = files_path
         self._translation_table = maketrans('\n\t', '  ')
@@ -30,9 +30,11 @@ class NonComplianceChecks:
             publisher = self._get_publisher_from_file_name(filename)
             with open(filename, 'r') as f:
                 lines = filter(lambda x: x != '',
-                               [line.strip() for line in f.readlines()])
+                               [line.strip('\n') for line in f.readlines()])
 
-            tmp[publisher] = RawTextSearch(lines[0].format(*lines[1:]))
+            tmp[publisher] = RawTextSearch(lines[0].format(*lines[1:]),
+                                           self.normal_search_delimiter,
+                                           self.regex_search_delimiter)
 
         return tmp
 

--- a/compliance_check_configs/authors_New J. Phys..cfg
+++ b/compliance_check_configs/authors_New J. Phys..cfg
@@ -1,3 +1,3 @@
-/({0})([0-9]* |)(to |)({1})/
+//({0})([0-9]* |)(to |)({1})//
 ^copyright | copyright |^c | c |^\(c\) | \(c\) |^© | ©
 iop|institute of physics

--- a/compliance_check_configs/authors_default.cfg
+++ b/compliance_check_configs/authors_default.cfg
@@ -1,3 +1,3 @@
--/({0})/ /({0})([0-9]* |)(to |)({1})/
-^copyright | copyright |^c | c |^\(c\) | \(c\) |^© | ©
+-//({0})// //({0})([0-9]* |)(to |)({1})//
+^copyright | copyright |^c | c |^\(c\) | \(c\) |^© | © |/© 
 iop|institute of physics|elsevier|hindawi|cas|chinese academy of science|sissa|dpg|deutsche physikalische gesellschaft|uj|jagiellonian university|oup|oxford university press|jps|physical society of japan|springer|sif|societa italiana di fisica

--- a/rawtext_search.py
+++ b/rawtext_search.py
@@ -1,22 +1,28 @@
 import re
 
+
 class RawTextSearch:
-    def __init__(self, searchstring):
+    def __init__(self, searchstring, normal_search_delimiter="'",
+                 regex_search_delimiter="/"):
         self.searchstring = searchstring
+
+        self.normal_search_delimiter = normal_search_delimiter
+        self.regex_search_delimiter = regex_search_delimiter
 
         self.operators = []
         self.operators.append((" ", "OR"))
         self.operators.append(("OR", "OR"))
         self.operators.append(("-", "NEG"))
-        self.operators.append(('\'', "none"))
-        self.operators.append(('/', "none"))
+        self.operators.append((self.normal_search_delimiter, "none"))
+        self.operators.append((self.regex_search_delimiter, "none"))
         self.operators.append(("(", "LBR"))
         self.operators.append((")", "RBR"))
 
         self.rules = [
             ("NEGT", ("NEG", "ST")),
             ("ST", ("NEGT",), ("LBR", "OR", "RBR"), ("LBR", "ST", "RBR")),
-            ("OR", ("ST", "OR", "ST"), ("OR", "OR", "ST"), ("ST", "OR", "OR"), ("OR", "OR", "OR"))
+            ("OR", ("ST", "OR", "ST"), ("OR", "OR", "ST"), ("ST", "OR", "OR"),
+             ("OR", "OR", "OR"))
         ]
 
         self.pick_rules = {
@@ -31,65 +37,56 @@ class RawTextSearch:
         }
 
         self.operator_actions = {
-            "ST": self.__st_action,
-            "OR": self.__or_action,
-            "NEGT": self.__neg_action
+            "ST": self._st_action,
+            "OR": self._or_action,
+            "NEGT": self._neg_action
         }
 
-        self.raw_splits = self.__split()
-        self.assigned_splits = self.__assign_meanings(self.raw_splits)
+        self.raw_splits = self._split()
+        self.assigned_splits = self._assign_meanings(self.raw_splits)
 
-        self.searchtree = self.__build_search_tree(self.assigned_splits)
+        self.searchtree = self._build_search_tree(self.assigned_splits)
 
-    def __st_action(self, results):
+    def _st_action(self, results):
         return results[0]
 
-    def __or_action(self, results):
+    def _or_action(self, results):
         val = False
         for result in results:
             val = val or result
         return val
 
-    def __neg_action(self, results):
+    def _neg_action(self, results):
         return not results[0]
 
     # SPLIT THE SEARCH INTO ATOMIC PARTS
-    def __is_operator(self, index):
+    def _get_operator_length(self, operator, index):
+        if operator[0] == self.normal_search_delimiter:
+            next_pos = self.searchstring.find(self.normal_search_delimiter,
+                                              index+1)
+            return next_pos-index+len(operator[0])
+        elif operator[0] == self.regex_search_delimiter:
+            next_pos = self.searchstring.find(self.regex_search_delimiter,
+                                              index+1)
+            return next_pos-index+len(operator[0])
+        else:
+            return len(operator[0])
+
+    def _operator_length(self, index):
         operator_length = 0
         for operator in self.operators:
             if operator[0] == self.searchstring[index:index+len(operator[0])]:
-                if operator[0] == '\'':
-                    next_position = self.searchstring.find('\'', index+1)
-                    return next_position-index+1
-                elif operator[0] == '/':
-                    next_position = self.searchstring.find('/', index+1)
-                    return next_position-index+1
-                else:
-                    return len(operator[0])
+                return self._get_operator_length(operator, index)
         return operator_length
 
-    def __is_searchterm(self, index):
-        substring = self.searchstring[index:]
-        for i in range(len(substring)):
-            char = substring[i]
-            if is_operator(i, substring):
-                return i
-        return len(substring)
-
-    def __split(self):
+    def _split(self):
         splits = []
 
         i = 0
         while i < len(self.searchstring):
-            char = self.searchstring[i]
-            operator_length = self.__is_operator(i)
-            if operator_length > 0:
-                splits.append(self.searchstring[i:i+operator_length])
-                i += operator_length
-            else:
-                searchterm_length = self.__is_searchterm(i, searchstring)
-                splits.append(self.searchstring[i:i+searchterm_length])
-                i += searchterm_length
+            operator_length = self._operator_length(i)
+            splits.append(self.searchstring[i:i+operator_length])
+            i += operator_length
 
         for i in range(len(splits)):
             if splits[i] == " ":
@@ -98,7 +95,7 @@ class RawTextSearch:
         return splits
 
     # ASSIGN MEANING TO THE ATOMIC PARTS
-    def __assign_meanings(self, splits):
+    def _assign_meanings(self, splits):
         new_splits = []
         for i in range(len(splits)):
             searchterm = True
@@ -111,7 +108,7 @@ class RawTextSearch:
         return new_splits
 
     #BUILD THE SEARCH TREE
-    def __fits_rule(self, subrule, index, new_splits):
+    def _fits_rule(self, subrule, index, new_splits):
         fits = True
         for i in range(len(subrule)):
             try:
@@ -123,7 +120,7 @@ class RawTextSearch:
                 break
         return fits
 
-    def __combine(self, rule, subrule, index, new_splits):
+    def _combine(self, rule, subrule, index, new_splits):
         tmp = new_splits
         new_tuple_list = [rule[0]]
         picks = self.pick_rules[subrule]
@@ -137,7 +134,7 @@ class RawTextSearch:
 
         return tmp
 
-    def __build_search_tree(self, splits):
+    def _build_search_tree(self, splits):
         new_splits = splits
         start_over = False
         while len(new_splits) != 1:
@@ -145,11 +142,11 @@ class RawTextSearch:
             for rule in self.rules:
                 for subrule in rule[1:]:
                     for i in range(len(new_splits)):
-                        if self.__fits_rule(subrule, i, new_splits):
-                            new_splits = self.__combine(rule,
-                                                        subrule,
-                                                        i,
-                                                        new_splits)
+                        if self._fits_rule(subrule, i, new_splits):
+                            new_splits = self._combine(rule,
+                                                       subrule,
+                                                       i,
+                                                       new_splits)
                             start_over = True
                             break
                     if start_over:
@@ -162,7 +159,7 @@ class RawTextSearch:
         return new_splits[0]
 
     #PRINT TREE
-    def __print_tree(self, new_split, indentation_level=0):
+    def _print_tree(self, new_split, indentation_level=0):
         indentation = ''
         for i in range(indentation_level):
             indentation += "\t"
@@ -170,7 +167,7 @@ class RawTextSearch:
         print indentation + new_split[0]
         for split in new_split[1:]:
             if isinstance(split, (list, tuple)):
-                self.__print_tree(split, indentation_level+1)
+                self._print_tree(split, indentation_level+1)
             else:
                 print indentation + '\t' + split
 
@@ -182,43 +179,46 @@ class RawTextSearch:
         print indentation + self.searchtree[0]
         for split in self.searchtree[1:]:
             if isinstance(split, (list, tuple)):
-                self.__print_tree(split, indentation_level+1)
+                self._print_tree(split, indentation_level+1)
             else:
                 print indentation + '\t' + split
 
     #SEARCH STUFF
-    def __is_regex(self, searchterm):
-        if searchterm[0] == '/':
+    def _is_regex(self, searchterm):
+        if searchterm.startswith(self.regex_search_delimiter):
             return True
         return False
 
-    def __get_active_operator(self, operator_string):
+    def _get_active_operator(self, operator_string):
         return self.operator_actions[operator_string]
 
-    def __clean_searchterm(self, searchterm):
-        if searchterm[0] == "'" or searchterm[0] == "/":
-            return searchterm[1:len(searchterm)-1]
+    def _clean_searchterm(self, searchterm):
+        if searchterm.startswith(self.normal_search_delimiter):
+            return searchterm.replace(self.normal_search_delimiter, '')
+        if searchterm.startswith(self.regex_search_delimiter):
+            return searchterm.replace(self.regex_search_delimiter, '')
+
         return searchterm
 
-    def __perform_search(self, raw_text, searchterm):
-        if not self.__is_regex(searchterm):
-            searchterm = self.__clean_searchterm(searchterm)
+    def _perform_search(self, raw_text, searchterm):
+        if not self._is_regex(searchterm):
+            searchterm = self._clean_searchterm(searchterm)
             return searchterm in raw_text
         else:
-            searchterm = self.__clean_searchterm(searchterm)
+            searchterm = self._clean_searchterm(searchterm)
             pattern = re.compile(searchterm, re.IGNORECASE)
             return pattern.search(raw_text) is not None
 
-    def __search(self, raw_text, searchtree):
+    def _search(self, raw_text, searchtree):
         active_operator = None
         results = []
 
         if isinstance(searchtree, (tuple)):
-            active_operator = self.__get_active_operator(searchtree[0])
+            active_operator = self._get_active_operator(searchtree[0])
             for sub_tree in searchtree[1:]:
-                results.append(self.__search(raw_text, sub_tree))
+                results.append(self._search(raw_text, sub_tree))
         else:
-            return self.__perform_search(raw_text, searchtree)
+            return self._perform_search(raw_text, searchtree)
 
         return active_operator(results)
 
@@ -227,56 +227,10 @@ class RawTextSearch:
         results = []
 
         if isinstance(self.searchtree, (tuple)):
-            active_operator = self.__get_active_operator(self.searchtree[0])
+            active_operator = self._get_active_operator(self.searchtree[0])
             for sub_tree in self.searchtree[1:]:
-                results.append(self.__search(raw_text, sub_tree))
+                results.append(self._search(raw_text, sub_tree))
         else:
-            return perform_search(raw_text, self.searchtree)
+            return self._perform_search(raw_text, self.searchtree)
 
         return active_operator(results)
-
-
-if __name__ == '__main__':
-    print 'Running some tests...'
-    # searchstring1 = "-'CC-BY' -'CC BY' -'Creative Commons Attribution'"
-    searchstring1 = "-('CC-BY' 'CC BY' 'Creative Commons Attribution')"
-    searchstring2 = "-'funded by SCOAP'"
-    searchstring3 = "-(/(c|\(c\)) the author/ 'copyright cern')"
-    searchstring4 = "/(copyright|c)[^.]*(IOP|Institute of Physics)/"
-
-    search1 = RawTextSearch(searchstring1)
-    search2 = RawTextSearch(searchstring2)
-    search3 = RawTextSearch(searchstring3)
-    search4 = RawTextSearch(searchstring4)
-
-    search1.print_tree()
-    search2.print_tree()
-    search3.print_tree()
-    search4.print_tree()
-
-    raw_text1 = '''
-       CC BY Banana
-       Open Access, c The Authors, (c) The Authors.
-       Article funded by SCOAP3.
-       c . Institute of Physics.
-       '''
-
-    raw_text2 = '''
-        Open Access
-        Article by SCOAP3.
-        c blah blah Institute of Physics.
-    '''
-
-    print "For the following text everything should be false"
-    print raw_text1
-    print search1.search(raw_text1)
-    print search2.search(raw_text1)
-    print search3.search(raw_text1)
-    print search4.search(raw_text1)
-
-    print "For the following text everything should be false"
-    print raw_text2
-    print search1.search(raw_text2)
-    print search2.search(raw_text2)
-    print search3.search(raw_text2)
-    print search4.search(raw_text2)


### PR DESCRIPTION
- Adds search delimiters to NonComplianceCheck and rawtext_search to
  remove a flaw, which would not allow to search for specific characters.
- Changes the configuration files to use // as regex delimiter.
- Some PEP8 and general code adjustments.

Signed-off-by: Martin Vesper martin.vesper@cern.ch
