### PR TITLE
Bibcheck: Changes chk_fix_latex's regex

### DIFF
--- a/chk_fix_latex.py
+++ b/chk_fix_latex.py
@@ -21,6 +21,20 @@ Fixes latex for Spinger
 from invenio.bibrecord import record_get_field_value
 import re
 
+
+def strip_latex(string):
+    for x in re.findall('\\\\document.*?end\{document\}', string, re.DOTALL):
+        string = string.replace(x, '')
+
+    for y in re.findall('\\\\setlength\{.*?\}\{.*?\}', string, re.DOTALL):
+        string = string.replace(y, '')
+
+    for x in re.findall('\\\\usepackage\{.*?\}', string, re.DOTALL):
+        string = string.replace(x, '')
+
+    return string.replace('  ', ' ').replace('\n', '').replace('\t', '')
+
+
 def check_records(records):
     for record in records:
         publisher = record_get_field_value(record, '980', code='b')
@@ -28,15 +42,12 @@ def check_records(records):
             title = record_get_field_value(record, '245', code='a')
             abstract = record_get_field_value(record, '520', code='a')
 
-            title = re.sub(r'\\documentclass\[\w*\]\{\w*\}| \\usepackage\{\w*\}| \\setlength\{\\\w*\}\{[\-]\w*\}', '', title)
-            abstract = re.sub(r'\\documentclass\[\w*\]\{\w*\}| \\usepackage\{\w*\}| \\setlength\{\\\w*\}\{[\-]\w*\}', '', abstract)
-            title = title.replace('\\begin{document}', '').replace('\\end{document}', '')
-            abstract = abstract.replace('\\begin{document}', '').replace('\\end{document}', '')
-            title = re.sub(r'\$\$.*?\$\$', '', title)
-            abstract = re.sub(r'\$\$.*?\$\$', '', abstract)
+            title = strip_latex(title)
+            abstract = strip_latex(abstract)
 
             for position, value in record.iterfield('245__a'):
                 record.amend_field(position, title)
 
             for position, value in record.iterfield('520__a'):
                 record.amend_field(position, abstract)
+


### PR DESCRIPTION
- Changes the used regex in chk_fix_latex to remove not-displayable
  latex.

Signed-off-by: Martin Vesper martin.vesper@cern.ch
