### PR TITLE
compliance-check: Adds correct search delimiter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ PREFIX = `python -c "from invenio.config import CFG_PREFIX; print CFG_PREFIX"`
 LIBDIR = $(PREFIX)/lib
 ETCDIR = $(PREFIX)/etc
 WWWDIR = $(PREFIX)/var/www
-#APACHE = `python -c "from invenio.bibtask import guess_apache_process_user; print guess_apache_process_user()"`
+APACHE = `python -c "from invenio.bibtask import guess_apache_process_user; print guess_apache_process_user()"`
 #APACHE = www-data
-APACHE = wojciech
+#APACHE = wojciech
 INSTALL = install -g $(APACHE)
 COPYDIR = cp -r
 

--- a/compliance_check.py
+++ b/compliance_check.py
@@ -44,7 +44,8 @@ def check_records(records, empty=False):
     path = join(CFG_PYLIBDIR,
                 'invenio/bibcheck_plugins/compliance_check_configs/')
     checks = NonComplianceChecks(compliance_names=['CC', 'Authors', 'SCOAP3'],
-                                 files_path=path)
+                                 files_path=path,
+                                 regex_search_delimiter='//')
 
     for record in records:
         dic = checks.check(record)

--- a/rawtext_search.py
+++ b/rawtext_search.py
@@ -85,6 +85,10 @@ class RawTextSearch:
         i = 0
         while i < len(self.searchstring):
             operator_length = self._operator_length(i)
+            if operator_length == 0:
+                raise Exception(('Infinite loop while splitting the search '
+                                 'string. Check your search_delimiters '
+                                 'or the search string.'))
             splits.append(self.searchstring[i:i+operator_length])
             i += operator_length
 


### PR DESCRIPTION
- Adds the currently used regex_search_delimiter (//) to
  compliance_check.py
- Now raises an exception in RawTextSearch in the case of a wrong
  search delimiter that would otherwise lead to an infinite loop.

Signed-off-by: Martin Vesper martin.vesper@cern.ch
