### PR TITLE
chk_fix_bad_elsevier_affiliations: first author

### DIFF
--- a/bibcheck_plugins/chk_fix_bad_elsevier_affiliations.py
+++ b/bibcheck_plugins/chk_fix_bad_elsevier_affiliations.py
@@ -166,9 +166,9 @@ def check_records(records, empty=False):
     fields = ['100', '700']
     filepath = "/opt/invenio/var/data/files/g0/"
     filepath2 = "/opt/invenio/var/data/files/g1/"
-    first_author = True
 
     for record in records:
+        first_author = True
         if is_elsevier(record):
             doc_ids = get_doc_ids(int(record.record_id))
             for doc_id in doc_ids:


### PR DESCRIPTION
- Fixes the issue where the first author would be placed in field '700' instead of '100'.
