### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/generate_scoap3_repo_page.py
+++ b/generate_scoap3_repo_page.py
@@ -47,7 +47,7 @@ def main():
             record = get_record(recid)
             title = remove_html_markup(record_get_field_value(record, '245', code='a'), remove_escaped_chars_p=False).strip()
             doi = record_get_field_value(record, '024', '7', code='a')
-            print '<li><a href="http://dx.doi.org/%s" target="_blank">%s</a>: %s</li>' % (escape(doi, True), escape(doi), title)
+            print '<li><a href="https://doi.org/%s" target="_blank">%s</a>: %s</li>' % (escape(doi, True), escape(doi), title)
         print "</ul></p>"
 
 if __name__ == "__main__":

--- a/scrape_springer.py
+++ b/scrape_springer.py
@@ -34,5 +34,5 @@ for article in articles:
     href = article.get('href')
     doi = href.replace("/article/", "").encode('utf8')
     title = article.getText(' ', True).strip().encode('utf8')
-    print '<li><a href="http://dx.doi.org/%s" target="_blank">%s</a>: %s</li>' % (escape(doi, True), escape(doi), title)
+    print '<li><a href="https://doi.org/%s" target="_blank">%s</a>: %s</li>' % (escape(doi, True), escape(doi), title)
 print "</ul></p>"

--- a/www/compliance.py
+++ b/www/compliance.py
@@ -310,7 +310,7 @@ def get_record_checks(req, recids):
                 <td><a href="%s">%i</a></td>
                 <td>%s</td>
                 <td>%s</td>
-                <td><a href="http://dx.doi.org/%s">%s</a></td>
+                <td><a href="https://doi.org/%s">%s</a></td>
                 <td>%s</td>
                 <td>%s</td>
                 <td>%s</td>

--- a/www/nations.py
+++ b/www/nations.py
@@ -194,7 +194,7 @@ def late(req):
     th = ("<tr><th>DOI</th><th>Title</th><th>DOI registration</th>"
           "<th>Arrival in SCOAP3</th></tr>")
     tr = ("<tr style='background-color: {0};'><td>"
-          "<a href='http://dx.doi.org/{1}' target='_blank'>{2}</td>"
+          "<a href='https://doi.org/{1}' target='_blank'>{2}</td>"
           "<td>{3}</td><td>{4}</td><td>{5}</td></tr>")
 
     sql_bibrec = "SELECT creation_date FROM bibrec WHERE id=%s"
@@ -265,9 +265,9 @@ def articles(req, i, mode='html'):
             title = record_get_field_value(record, '245', code='a')
             doi = record_get_field_value(record, '024', '7', code='a')
             if mode == 'text':
-                print >> req, "http://dx.doi.org/%s" % doi
+                print >> req, "https://doi.org/%s" % doi
 
-            li = ("<li><a href='http://dx.doi.org/{0}' "
+            li = ("<li><a href='https://doi.org/{0}' "
                   "target='_blank'>{1}</a>: {2}</li>")
             ret.append(li.format(escape(doi, True), escape(doi), title))
         ret.append("</ul></p>")


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update any code that generates new DOI links.

Cheers!